### PR TITLE
import darker/lighter from rgb to hsl

### DIFF
--- a/src/hsl.js
+++ b/src/hsl.js
@@ -1,5 +1,5 @@
 import {default as color, Color} from "./color";
-import {default as rgb, Rgb} from "./rgb";
+import {default as rgb, Rgb, darker, lighter} from "./rgb";
 
 export default function(h, s, l) {
   if (arguments.length === 1) {


### PR DESCRIPTION
After fixing https://github.com/rollup/rollup/issues/20, it looks like `darker` and `brighter` need to be imported here