### PR TITLE
Fix RGB values range

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Changes from D3 3.x:
 
 * When converting from Lab to HCL, hue and chroma are no longer undefined if the luminance is zero. Thus, the roundtrip from Lab to HCL and back again no longer loses information.
 
-* Colors are now validated upon construction. For example, an RGB color’s `r`, `g` and `b` values are integers in the range [0,100]; an HSL color’s `s` and `l` are numbers in the range [0,1].
+* Colors are now validated upon construction. For example, an RGB color’s `r`, `g` and `b` values are integers in the range [0,255]; an HSL color’s `s` and `l` are numbers in the range [0,1].
 
 <a name="color" href="#color">#</a> <b>color</b>(<i>specifier</i>)
 


### PR DESCRIPTION
Looks like a typo, RGB is validated for [0,255]:
https://github.com/d3/d3-color/blob/master/src/rgb.js#L18