### PR TITLE
Avoid circular deps

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,7 +6,7 @@
   ],
   "browser": true,
   "boss": true,
-  "curly": true,
+  "curly": false,
   "debug": false,
   "devel": true,
   "eqeqeq": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,32 @@
+{
+  "predef": [
+    "document",
+    "window",
+    "-Promise"
+  ],
+  "browser": true,
+  "boss": true,
+  "curly": true,
+  "debug": false,
+  "devel": true,
+  "eqeqeq": true,
+  "evil": true,
+  "forin": false,
+  "immed": false,
+  "laxbreak": false,
+  "newcap": true,
+  "noarg": true,
+  "noempty": false,
+  "nonew": false,
+  "nomen": false,
+  "onevar": false,
+  "plusplus": false,
+  "regexp": false,
+  "undef": true,
+  "sub": true,
+  "strict": false,
+  "white": false,
+  "eqnull": true,
+  "esnext": true,
+  "unused": true
+}

--- a/src/color.js
+++ b/src/color.js
@@ -1,7 +1,6 @@
 import rgb from "./rgb";
 import hsl from "./hsl";
-
-export function Color() {};
+import {Color} from './colorFn';
 
 var reHex3 = /^#([0-9a-f]{3})$/,
     reHex6 = /^#([0-9a-f]{6})$/,
@@ -9,14 +8,7 @@ var reHex3 = /^#([0-9a-f]{3})$/,
     reRgbPercent = /^rgb\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/,
     reHslPercent = /^hsl\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/;
 
-color.prototype = Color.prototype = {
-  displayable: function() {
-    return this.rgb().displayable();
-  },
-  toString: function() {
-    return this.rgb() + "";
-  }
-};
+color.prototype = Color.prototype;
 
 export default function color(format) {
   var m;

--- a/src/color.js
+++ b/src/color.js
@@ -1,6 +1,6 @@
+import {Color} from './colorFn';
 import rgb from "./rgb";
 import hsl from "./hsl";
-import {Color} from './colorFn';
 
 var reHex3 = /^#([0-9a-f]{3})$/,
     reHex6 = /^#([0-9a-f]{6})$/,

--- a/src/color.js
+++ b/src/color.js
@@ -20,7 +20,7 @@ export default function color(format) {
       : (m = reHslPercent.exec(format)) ? hsl(m[1], m[2] / 100, m[3] / 100) // hsl(120,50%,50%)
       : named.hasOwnProperty(format) ? rgbn(named[format])
       : null;
-};
+}
 
 function rgbn(n) {
   return rgb(n >> 16 & 0xff, n >> 8 & 0xff, n & 0xff);

--- a/src/colorFn.js
+++ b/src/colorFn.js
@@ -1,4 +1,4 @@
-export function Color() {};
+export function Color() {}
 
 Color.prototype = {
   displayable: function() {

--- a/src/colorFn.js
+++ b/src/colorFn.js
@@ -1,0 +1,10 @@
+export function Color() {};
+
+Color.prototype = {
+  displayable: function() {
+    return this.rgb().displayable();
+  },
+  toString: function() {
+    return this.rgb() + "";
+  }
+};

--- a/src/cubehelix.js
+++ b/src/cubehelix.js
@@ -1,4 +1,5 @@
-import {default as color, Color} from "./color";
+import {default as color} from "./color";
+import {Color} from './colorFn';
 import {default as rgb, Rgb, darker, brighter} from "./rgb";
 import {deg2rad, rad2deg} from "./hcl";
 

--- a/src/cubehelix.js
+++ b/src/cubehelix.js
@@ -1,4 +1,3 @@
-import {default as color} from "./color";
 import {Color} from './colorFn';
 import {default as rgb, Rgb, darker, brighter} from "./rgb";
 import {deg2rad, rad2deg} from "./hcl";

--- a/src/cubehelix.js
+++ b/src/cubehelix.js
@@ -18,25 +18,25 @@ export default function cubehelix(h, s, l) {
       s = h.s;
       h = h.h;
     } else {
-      if (!(h instanceof Rgb)) h = rgb(h);
+      if (!(h instanceof Rgb)) { h = rgb(h); }
       var r = h.r / 255, g = h.g / 255, b = h.b / 255;
       l = (BC_DA * b + ED * r - EB * g) / (BC_DA + ED - EB);
       var bl = b - l, k = (E * (g - l) - C * bl) / D;
       s = Math.sqrt(k * k + bl * bl) / (E * l * (1 - l)); // NaN if l=0 or l=1
       h = s ? Math.atan2(k, bl) * rad2deg - 120 : NaN;
-      if (h < 0) h += 360;
+      if (h < 0) { h += 360; }
     }
   }
   return new Cubehelix(h, s, l);
-};
+}
 
 export function Cubehelix(h, s, l) {
   this.h = +h;
   this.s = +s;
   this.l = +l;
-};
+}
 
-var prototype = cubehelix.prototype = Cubehelix.prototype = new Color;
+var prototype = cubehelix.prototype = Cubehelix.prototype = new Color();
 
 prototype.brighter = function(k) {
   k = k == null ? brighter : Math.pow(brighter, k);

--- a/src/hcl.js
+++ b/src/hcl.js
@@ -11,21 +11,21 @@ export default function hcl(h, c, l) {
       c = h.c;
       h = h.h;
     } else {
-      if (!(h instanceof Lab)) h = lab(h);
+      if (!(h instanceof Lab)) {h = lab(h);}
       l = h.l;
       c = Math.sqrt(h.a * h.a + h.b * h.b);
       h = Math.atan2(h.b, h.a) * rad2deg;
-      if (h < 0) h += 360;
+      if (h < 0) {h += 360;}
     }
   }
   return new Hcl(h, c, l);
-};
+}
 
 export function Hcl(h, c, l) {
   this.h = +h;
   this.c = +c;
   this.l = +l;
-};
+}
 
 var prototype = hcl.prototype = Hcl.prototype = new Color();
 

--- a/src/hcl.js
+++ b/src/hcl.js
@@ -1,5 +1,4 @@
 import {Color} from './colorFn';
-import {default as color} from "./color";
 import {default as lab, Lab, Kn} from "./lab";
 
 export var deg2rad = Math.PI / 180;

--- a/src/hcl.js
+++ b/src/hcl.js
@@ -1,4 +1,5 @@
-import {default as color, Color} from "./color";
+import {Color} from './colorFn';
+import {default as color} from "./color";
 import {default as lab, Lab, Kn} from "./lab";
 
 export var deg2rad = Math.PI / 180;
@@ -27,7 +28,7 @@ export function Hcl(h, c, l) {
   this.l = +l;
 };
 
-var prototype = hcl.prototype = Hcl.prototype = new Color;
+var prototype = hcl.prototype = Hcl.prototype = new Color();
 
 prototype.brighter = function(k) {
   return new Hcl(this.h, this.c, this.l + Kn * (k == null ? 1 : k));

--- a/src/hsl.js
+++ b/src/hsl.js
@@ -1,4 +1,5 @@
-import {default as color, Color} from "./color";
+import {Color} from './colorFn';
+import {default as color} from "./color";
 import {default as rgb, Rgb, darker, brighter} from "./rgb";
 
 export default function hsl(h, s, l) {

--- a/src/hsl.js
+++ b/src/hsl.js
@@ -1,6 +1,6 @@
 import {Color} from './colorFn';
 import {default as color} from "./color";
-import {default as rgb, Rgb, darker, brighter} from "./rgb";
+import {Rgb, darker, brighter} from "./rgb";
 
 export default function hsl(h, s, l) {
   if (arguments.length === 1) {

--- a/src/hsl.js
+++ b/src/hsl.js
@@ -36,13 +36,13 @@ export default function hsl(h, s, l) {
     }
   }
   return new Hsl(h, s, l);
-};
+}
 
 export function Hsl(h, s, l) {
   this.h = +h;
   this.s = +s;
   this.l = +l;
-};
+}
 
 var prototype = hsl.prototype = Hsl.prototype = new Color();
 
@@ -60,7 +60,7 @@ prototype.rgb = function() {
   var h = this.h % 360 + (this.h < 0) * 360,
       s = isNaN(h) || isNaN(this.s) ? 0 : this.s,
       l = this.l,
-      m2 = l + (l < .5 ? l : 1 - l) * s,
+      m2 = l + (l < 0.5 ? l : 1 - l) * s,
       m1 = 2 * l - m2;
   return new Rgb(
     hsl2rgb(h >= 240 ? h - 240 : h + 120, m1, m2),
@@ -70,8 +70,8 @@ prototype.rgb = function() {
 };
 
 prototype.displayable = function() {
-  return (0 <= this.s && this.s <= 1 || isNaN(this.s))
-      && (0 <= this.l && this.l <= 1);
+  return (0 <= this.s && this.s <= 1 || isNaN(this.s)) &&
+         (0 <= this.l && this.l <= 1);
 };
 
 /* From FvD 13.37, CSS Color Module Level 3 */

--- a/src/hsl.js
+++ b/src/hsl.js
@@ -44,7 +44,7 @@ export function Hsl(h, s, l) {
   this.l = +l;
 };
 
-var prototype = hsl.prototype = Hsl.prototype = new Color;
+var prototype = hsl.prototype = Hsl.prototype = new Color();
 
 prototype.brighter = function(k) {
   k = k == null ? brighter : Math.pow(brighter, k);

--- a/src/lab.js
+++ b/src/lab.js
@@ -26,9 +26,9 @@ export default function lab(l, a, b) {
     } else {
       if (!(l instanceof Rgb)) l = rgb(l);
       var r = rgb2xyz(l.r),
-          g = rgb2xyz(l.g),
-          b = rgb2xyz(l.b),
-          x = xyz2lab((0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / Xn),
+          g = rgb2xyz(l.g);
+          b = rgb2xyz(l.b);
+      var x = xyz2lab((0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / Xn),
           y = xyz2lab((0.2126729 * r + 0.7151522 * g + 0.0721750 * b) / Yn),
           z = xyz2lab((0.0193339 * r + 0.1191920 * g + 0.9503041 * b) / Zn);
       b = 200 * (y - z);
@@ -37,13 +37,13 @@ export default function lab(l, a, b) {
     }
   }
   return new Lab(l, a, b);
-};
+}
 
 export function Lab(l, a, b) {
   this.l = +l;
   this.a = +a;
   this.b = +b;
-};
+}
 
 var prototype = lab.prototype = Lab.prototype = new Color();
 

--- a/src/lab.js
+++ b/src/lab.js
@@ -45,7 +45,7 @@ export function Lab(l, a, b) {
   this.b = +b;
 };
 
-var prototype = lab.prototype = Lab.prototype = new Color;
+var prototype = lab.prototype = Lab.prototype = new Color();
 
 prototype.brighter = function(k) {
   return new Lab(this.l + Kn * (k == null ? 1 : k), this.a, this.b);

--- a/src/lab.js
+++ b/src/lab.js
@@ -1,4 +1,5 @@
-import {default as color, Color} from "./color";
+import {Color} from './colorFn';
+import {default as color} from "./color";
 import {default as rgb, Rgb} from "./rgb";
 import {default as hcl, Hcl, deg2rad} from "./hcl";
 

--- a/src/lab.js
+++ b/src/lab.js
@@ -1,7 +1,6 @@
 import {Color} from './colorFn';
-import {default as color} from "./color";
 import {default as rgb, Rgb} from "./rgb";
-import {default as hcl, Hcl, deg2rad} from "./hcl";
+import {Hcl, deg2rad} from "./hcl";
 
 export var Kn = 18;
 

--- a/src/rgb.js
+++ b/src/rgb.js
@@ -1,7 +1,7 @@
 import {Color} from './colorFn';
 import {default as color} from "./color";
 
-export var darker = .7;
+export var darker = 0.7;
 export var brighter = 1 / darker;
 
 export default function rgb(r, g, b) {
@@ -17,13 +17,13 @@ export default function rgb(r, g, b) {
     }
   }
   return new Rgb(r, g, b);
-};
+}
 
 export function Rgb(r, g, b) {
   this.r = +r;
   this.g = +g;
   this.b = +b;
-};
+}
 
 var prototype = rgb.prototype = Rgb.prototype = new Color();
 
@@ -42,17 +42,17 @@ prototype.rgb = function() {
 };
 
 prototype.displayable = function() {
-  return (0 <= this.r && this.r <= 255)
-      && (0 <= this.g && this.g <= 255)
-      && (0 <= this.b && this.b <= 255);
+  return (0 <= this.r && this.r <= 255) &&
+         (0 <= this.g && this.g <= 255) &&
+         (0 <= this.b && this.b <= 255);
 };
 
 prototype.toString = function() {
   var r = Math.round(this.r),
       g = Math.round(this.g),
       b = Math.round(this.b);
-  return "#"
-      + (isNaN(r) || r <= 0 ? "00" : r < 16 ? "0" + r.toString(16) : r >= 255 ? "ff" : r.toString(16))
-      + (isNaN(g) || g <= 0 ? "00" : g < 16 ? "0" + g.toString(16) : g >= 255 ? "ff" : g.toString(16))
-      + (isNaN(b) || b <= 0 ? "00" : b < 16 ? "0" + b.toString(16) : b >= 255 ? "ff" : b.toString(16));
+  return "#" +
+      (isNaN(r) || r <= 0 ? "00" : r < 16 ? "0" + r.toString(16) : r >= 255 ? "ff" : r.toString(16)) +
+      (isNaN(g) || g <= 0 ? "00" : g < 16 ? "0" + g.toString(16) : g >= 255 ? "ff" : g.toString(16)) +
+      (isNaN(b) || b <= 0 ? "00" : b < 16 ? "0" + b.toString(16) : b >= 255 ? "ff" : b.toString(16));
 };

--- a/src/rgb.js
+++ b/src/rgb.js
@@ -1,4 +1,5 @@
-import {default as color, Color} from "./color";
+import {Color} from './colorFn';
+import {default as color} from "./color";
 
 export var darker = .7;
 export var brighter = 1 / darker;

--- a/src/rgb.js
+++ b/src/rgb.js
@@ -25,7 +25,7 @@ export function Rgb(r, g, b) {
   this.b = +b;
 };
 
-var prototype = rgb.prototype = Rgb.prototype = new Color;
+var prototype = rgb.prototype = Rgb.prototype = new Color();
 
 prototype.brighter = function(k) {
   k = k == null ? brighter : Math.pow(brighter, k);


### PR DESCRIPTION
Due to a limitation in the AMD module loader, `d3-color` cannot be compiled by Babel.js because it produces a build which doesn't include the circular reference to `Color.prototype`, causing all the additional color functions to fail.

Why am I compiling this to AMD? Because of Ember.js. Unfortunately UMD as output by this project cannot be loaded by Ember and there is are no plans to support anonymous module loaders, so the Ember Addon `ember-cli-d3-primitive` recompiles the ESNext sources to AMD using Babel.
