### PR TITLE
Apply chromatic adaptation between D50 and D65 standard referents

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -n d3 -o build/d3-color.js -- index.js",
-    "test": "tape 'test/**/*-test.js' && eslint index.js src test",
+    "test": "tape 'test/**/*-test.js' | tap-spec && eslint index.js src test",
     "prepublish": "npm run test && uglifyjs --preamble \"$(preamble)\" build/d3-color.js -c -m -o build/d3-color.min.js",
     "postpublish": "git push && git push --tags && cd ../d3.github.com && cp ../d3-color/build/d3-color.js d3-color.v1.js && cp ../d3-color/build/d3-color.min.js d3-color.v1.min.js && git add d3-color.v1.js d3-color.v1.min.js && git commit -m \"d3-color ${npm_package_version}\" && git push && cd - && zip -j build/d3-color.zip -- LICENSE README.md build/d3-color.js build/d3-color.min.js"
   },
@@ -37,6 +37,7 @@
     "package-preamble": "0.0",
     "rollup": "0.41",
     "tape": "4",
+    "tap-spec": "^4.1.1",
     "uglify-js": "^2.8.11"
   }
 }

--- a/src/lab.js
+++ b/src/lab.js
@@ -72,7 +72,7 @@ function xyz2lab(t) {
 }
 
 function lab2xyz(t) {
-  return t > t1 ? Math.pow(t, 3) : t2 * (t - t0);
+  return t > t1 ? t * t * t : t2 * (t - t0);
 }
 
 function lrgb2rgb(x) {

--- a/src/lab.js
+++ b/src/lab.js
@@ -3,9 +3,9 @@ import {Color, rgbConvert, Rgb} from "./color";
 import {deg2rad, rad2deg} from "./math";
 
 var Kn = 18,
-    Xn = 0.950470, // D65 standard referent
-    Yn = 1,
-    Zn = 1.088830,
+    Xn = 0.9642, // D50 standard referent
+    Yn = 1.0000,
+    Zn = 0.8249,
     t0 = 4 / 29,
     t1 = 6 / 29,
     t2 = 3 * t1 * t1,
@@ -18,12 +18,10 @@ function labConvert(o) {
     return new Lab(o.l, Math.cos(h) * o.c, Math.sin(h) * o.c, o.opacity);
   }
   if (!(o instanceof Rgb)) o = rgbConvert(o);
-  var b = rgb2xyz(o.r),
-      a = rgb2xyz(o.g),
-      l = rgb2xyz(o.b),
-      x = xyz2lab((0.4124564 * b + 0.3575761 * a + 0.1804375 * l) / Xn),
-      y = xyz2lab((0.2126729 * b + 0.7151522 * a + 0.0721750 * l) / Yn),
-      z = xyz2lab((0.0193339 * b + 0.1191920 * a + 0.9503041 * l) / Zn);
+  var xyz = rgb2xyz(o.r, o.g, o.b),
+      x = xyz2lab(xyz.x / Xn),
+      y = xyz2lab(xyz.y / Yn),
+      z = xyz2lab(xyz.z / Zn);
   return new Lab(116 * y - 16, 500 * (x - y), 200 * (y - z), o.opacity);
 }
 
@@ -48,16 +46,13 @@ define(Lab, lab, extend(Color, {
   rgb: function() {
     var y = (this.l + 16) / 116,
         x = isNaN(this.a) ? y : y + this.a / 500,
-        z = isNaN(this.b) ? y : y - this.b / 200;
-    y = Yn * lab2xyz(y);
-    x = Xn * lab2xyz(x);
-    z = Zn * lab2xyz(z);
-    return new Rgb(
-      xyz2rgb( 3.2404542 * x - 1.5371385 * y - 0.4985314 * z), // D65 -> sRGB
-      xyz2rgb(-0.9692660 * x + 1.8760108 * y + 0.0415560 * z),
-      xyz2rgb( 0.0556434 * x - 0.2040259 * y + 1.0572252 * z),
-      this.opacity
-    );
+        z = isNaN(this.b) ? y : y - this.b / 200,
+        rgb = xyz2rgb(
+          Xn * lab2xyz(x),
+          Yn * lab2xyz(y),
+          Zn * lab2xyz(z)
+        );
+    return new Rgb(rgb.r, rgb.g, rgb.b, this.opacity);
   }
 }));
 
@@ -66,14 +61,41 @@ function xyz2lab(t) {
 }
 
 function lab2xyz(t) {
-  return t > t1 ? t * t * t : t2 * (t - t0);
+  return t > t1 ? Math.pow(t, 3) : t2 * (t - t0);
 }
 
-function xyz2rgb(x) {
+function lrgb2rgb(x) {
   return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
 }
 
-function rgb2xyz(x) {
+function xyz2rgb(x, y, z) {
+  // D50 -> D65
+  var x1 = x * 0.9555766 - y * 0.0230393 + z * 0.0631636;
+  var y1 = x * -0.0282895 + y * 1.0099416 + z * 0.0210077;
+  var z1 = x * 0.0122982 - y * 0.0204830 + z * 1.3299098;
+  return {
+    r: lrgb2rgb(3.2404542 * x1 - 1.5371385 * y1 - 0.4985314 * z1),
+    g: lrgb2rgb(-0.9692660 * x1 + 1.8760108 * y1 + 0.0415560 * z1),
+    b: lrgb2rgb(0.0556434 * x1 - 0.2040259 * y1 + 1.0572252 * z1)
+  };
+}
+
+function rgb2xyz(r, g, b) {
+  r = rgb2lrgb(r), g = rgb2lrgb(g), b = rgb2lrgb(b);
+  var x = 0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
+      y = 0.2126729 * r + 0.7151522 * g + 0.0721750 * b,
+      z = 0.0193339 * r + 0.1191920 * g + 0.9503041 * b;
+  // D65 -> D50
+  return {
+    x: x * 1.0478112 + y * 0.0228866 - z * 0.0501270,
+    y: x * 0.0295424 + y * 0.9904844 - z * 0.0170491,
+    z: x * -0.0092345 + y * 0.0150436 + z * 0.7521316
+  };
+}
+
+
+
+function rgb2lrgb(x) {
   return (x /= 255) <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
 }
 

--- a/src/lab.js
+++ b/src/lab.js
@@ -5,7 +5,7 @@ import {deg2rad, rad2deg} from "./math";
 var Kn = 18,
     Xn = 0.9642, // D50 standard referent
     Yn = 1.0000,
-    Zn = 0.8249,
+    Zn = 0.82521,
     t0 = 4 / 29,
     t1 = 6 / 29,
     t2 = 3 * t1 * t1,
@@ -18,10 +18,15 @@ function labConvert(o) {
     return new Lab(o.l, Math.cos(h) * o.c, Math.sin(h) * o.c, o.opacity);
   }
   if (!(o instanceof Rgb)) o = rgbConvert(o);
-  var xyz = rgb2xyz(o.r, o.g, o.b),
-      x = xyz2lab(xyz.x / Xn),
-      y = xyz2lab(xyz.y / Yn),
-      z = xyz2lab(xyz.z / Zn);
+  var r = rgb2lrgb(o.r), 
+      g = rgb2lrgb(o.g),
+      b = rgb2lrgb(o.b),
+
+      // linear RGB -> XYZ (D50)
+      // http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
+      x = xyz2lab((0.4360747 * r + 0.3850649 * g + 0.1430804 * b) / Xn),
+      y = xyz2lab((0.2225045 * r + 0.7168786 * g + 0.0606169 * b) / Yn),
+      z = xyz2lab((0.0139322 * r + 0.0971045 * g + 0.7141733 * b) / Zn);
   return new Lab(116 * y - 16, 500 * (x - y), 200 * (y - z), o.opacity);
 }
 
@@ -46,13 +51,19 @@ define(Lab, lab, extend(Color, {
   rgb: function() {
     var y = (this.l + 16) / 116,
         x = isNaN(this.a) ? y : y + this.a / 500,
-        z = isNaN(this.b) ? y : y - this.b / 200,
-        rgb = xyz2rgb(
-          Xn * lab2xyz(x),
-          Yn * lab2xyz(y),
-          Zn * lab2xyz(z)
-        );
-    return new Rgb(rgb.r, rgb.g, rgb.b, this.opacity);
+        z = isNaN(this.b) ? y : y - this.b / 200;
+
+    x = Xn * lab2xyz(x);
+    y = Yn * lab2xyz(y);
+    z = Zn * lab2xyz(z);
+    
+    // XYZ (D50) -> linear RGB
+    // http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
+    var r =  3.1338561 * x - 1.6168667 * y - 0.4906146 * z,
+        g = -0.9787684 * x + 1.9161415 * y + 0.0334540 * z,
+        b =  0.0719453 * x - 0.2289914 * y + 1.4052427 * z;
+
+    return new Rgb(lrgb2rgb(r), lrgb2rgb(g), lrgb2rgb(b), this.opacity);
   }
 }));
 
@@ -67,33 +78,6 @@ function lab2xyz(t) {
 function lrgb2rgb(x) {
   return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
 }
-
-function xyz2rgb(x, y, z) {
-  // D50 -> D65
-  var x1 = x * 0.9555766 - y * 0.0230393 + z * 0.0631636;
-  var y1 = x * -0.0282895 + y * 1.0099416 + z * 0.0210077;
-  var z1 = x * 0.0122982 - y * 0.0204830 + z * 1.3299098;
-  return {
-    r: lrgb2rgb(3.2404542 * x1 - 1.5371385 * y1 - 0.4985314 * z1),
-    g: lrgb2rgb(-0.9692660 * x1 + 1.8760108 * y1 + 0.0415560 * z1),
-    b: lrgb2rgb(0.0556434 * x1 - 0.2040259 * y1 + 1.0572252 * z1)
-  };
-}
-
-function rgb2xyz(r, g, b) {
-  r = rgb2lrgb(r), g = rgb2lrgb(g), b = rgb2lrgb(b);
-  var x = 0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
-      y = 0.2126729 * r + 0.7151522 * g + 0.0721750 * b,
-      z = 0.0193339 * r + 0.1191920 * g + 0.9503041 * b;
-  // D65 -> D50
-  return {
-    x: x * 1.0478112 + y * 0.0228866 - z * 0.0501270,
-    y: x * 0.0295424 + y * 0.9904844 - z * 0.0170491,
-    z: x * -0.0092345 + y * 0.0150436 + z * 0.7521316
-  };
-}
-
-
 
 function rgb2lrgb(x) {
   return (x /= 255) <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);

--- a/test/hcl-test.js
+++ b/test/hcl-test.js
@@ -13,7 +13,7 @@ tape("hcl(…) returns an instance of hcl and color", function(test) {
 });
 
 tape("hcl(…) exposes h, c, and l channel values", function(test) {
-  test.hclEqual(color.hcl("#abc"), 257.7177616818892, 10.774886733325554, 75.10497524893663, 1);
+  test.hclEqual(color.hcl("#abc"), 252.38452899046413, 11.222753486232566, 74.96879980931759, 1);
   test.end();
 });
 
@@ -21,9 +21,9 @@ tape("hcl(…) returns defined hue and chroma, even for black and white", functi
   test.hclEqual(color.hcl("black"), 0, 0, 0, 1);
   test.hclEqual(color.hcl("#000"), 0, 0, 0, 1);
   test.hclEqual(color.hcl(color.lab("#000")), 0, 0, 0, 1);
-  test.hclEqual(color.hcl("white"), 158.19859051364818, 0.00001795054880958058, 100.00000386666655, 1);
-  test.hclEqual(color.hcl("#fff"), 158.19859051364818, 0.00001795054880958058, 100.00000386666655, 1);
-  test.hclEqual(color.hcl(color.lab("#fff")), 158.19859051364818, 0.00001795054880958058, 100.00000386666655, 1);
+  test.hclEqual(color.hcl("white"), 0, 0.003457073518231546, 100, 1);
+  test.hclEqual(color.hcl("#fff"), 0, 0.003457073518231546, 100, 1);
+  test.hclEqual(color.hcl(color.lab("#fff")), 0, 0.003457073518231546, 100, 1);
   test.end();
 });
 
@@ -112,14 +112,14 @@ tape("hcl(h, c, l, opacity) converts undefined opacity to 1", function(test) {
 });
 
 tape("hcl(format) parses the specified format and converts to HCL", function(test) {
-  test.hclEqual(color.hcl("#abcdef"), 259.84214815790716, 20.768234621934273, 81.04386565274363, 1);
-  test.hclEqual(color.hcl("#abc"), 257.7177616818892, 10.774886733325554, 75.10497524893663, 1);
-  test.hclEqual(color.hcl("rgb(12, 34, 56)"), 270.41717207657933, 16.833655998102003, 12.65624852526134, 1);
-  test.hclEqual(color.hcl("rgb(12%, 34%, 56%)"), 274.03009307843763, 36.289366963489435, 36.040298589825746, 1);
-  test.hclEqual(color.hcl("rgba(12%, 34%, 56%, 0.4)"), 274.03009307843763, 36.289366963489435, 36.040298589825746, 0.4);
-  test.hclEqual(color.hcl("hsl(60,100%,20%)"), 102.85124420310271, 49.44871600399321, 41.73251953866431, 1);
-  test.hclEqual(color.hcl("hsla(60,100%,20%,0.4)"), 102.85124420310271, 49.44871600399321, 41.73251953866431, 0.4);
-  test.hclEqual(color.hcl("aliceblue"), 252.44447593419056, 4.4710949781436735, 97.17864982306108, 1);
+  test.hclEqual(color.hcl("#abcdef"), 254.01521171170998, 21.62179282519733, 80.77135418262527, 1);
+  test.hclEqual(color.hcl("#abc"), 252.38452899046413, 11.222753486232566, 74.96879980931759, 1);
+  test.hclEqual(color.hcl("rgb(12, 34, 56)"), 262.83193442364876, 17.30336854563012, 12.404844123471648, 1);
+  test.hclEqual(color.hcl("rgb(12%, 34%, 56%)"), 266.119994747536, 37.03601810151972, 35.48300043476593, 1);
+  test.hclEqual(color.hcl("rgba(12%, 34%, 56%, 0.4)"), 266.119994747536, 37.03601810151972, 35.48300043476593, 0.4);
+  test.hclEqual(color.hcl("hsl(60,100%,20%)"), 99.57263208475133, 48.32704508820097, 41.97125732118659, 1);
+  test.hclEqual(color.hcl("hsla(60,100%,20%,0.4)"), 99.57263208475133, 48.32704508820097, 41.97125732118659, 0.4);
+  test.hclEqual(color.hcl("aliceblue"), 247.77343920212564, 4.680460380032747, 97.12294991108756, 1);
   test.end();
 });
 
@@ -149,7 +149,7 @@ tape("hcl(lab) returns defined hue, even if a and b are non-zero", function(test
 });
 
 tape("hcl(rgb) converts from RGB", function(test) {
-  test.hclEqual(color.hcl(color.rgb(255, 0, 0, 0.4)), 39.99901061253294, 104.55176567686985, 53.24079414130722, 0.4);
+  test.hclEqual(color.hcl(color.rgb(255, 0, 0, 0.4)), 40.851681934143315, 106.84100660249126, 54.29173376861782, 0.4);
   test.end();
 });
 
@@ -158,23 +158,23 @@ tape("hcl(color) converts from another colorspace via color.rgb()", function(tes
   TestColor.prototype = Object.create(color.color.prototype);
   TestColor.prototype.rgb = function() { return color.rgb(12, 34, 56, 0.4); };
   TestColor.prototype.toString = function() { throw new Error("should use rgb, not toString"); };
-  test.hclEqual(color.hcl(new TestColor), 270.41717207657933, 16.833655998102003, 12.65624852526134, 0.4);
+  test.hclEqual(color.hcl(new TestColor), 262.83193442364876, 17.30336854563012, 12.404844123471648, 0.4);
   test.end();
 });
 
 tape("hcl.brighter(k) returns a brighter color if k > 0", function(test) {
   var c = color.hcl("rgba(165, 42, 42, 0.4)");
-  test.hclEqual(c.brighter(0.5), 31.577795955065785, 58.32679960239559, 46.52650524281069, 0.4);
-  test.hclEqual(c.brighter(1), 31.577795955065785, 58.32679960239559, 55.52650524281069, 0.4);
-  test.hclEqual(c.brighter(2), 31.577795955065785, 58.32679960239559, 73.52650524281069, 0.4);
+  test.hclEqual(c.brighter(0.5), 32.282417816884454, 59.60396926239275, 47.149667346714935, 0.4);
+  test.hclEqual(c.brighter(1), 32.282417816884454, 59.60396926239275, 56.149667346714935, 0.4);
+  test.hclEqual(c.brighter(2), 32.282417816884454, 59.60396926239275, 74.14966734671493, 0.4);
   test.end();
 });
 
 tape("hcl.brighter(k) returns a copy", function(test) {
   var c1 = color.hcl("rgba(70, 130, 180, 0.4)"),
       c2 = c1.brighter(1);
-  test.hclEqual(c1, 262.78126775909277, 32.44906314974561, 52.46551718768575, 0.4);
-  test.hclEqual(c2, 262.78126775909277, 32.44906314974561, 70.46551718768575, 0.4);
+  test.hclEqual(c1, 255.71331691921011, 33.88051838788065, 51.98624890550498, 0.4);
+  test.hclEqual(c2, 255.71331691921011, 33.88051838788065, 69.98624890550498, 0.4);
   test.end();
 });
 
@@ -196,17 +196,17 @@ tape("hcl.brighter(k) is equivalent to hcl.darker(-k)", function(test) {
 
 tape("hcl.darker(k) returns a darker color if k > 0", function(test) {
   var c = color.hcl("rgba(165, 42, 42, 0.4)");
-  test.hclEqual(c.darker(0.5), 31.577795955065785, 58.32679960239559, 28.526505242810693, 0.4);
-  test.hclEqual(c.darker(1), 31.577795955065785, 58.32679960239559, 19.526505242810693, 0.4);
-  test.hclEqual(c.darker(2), 31.577795955065785, 58.32679960239559, 1.5265052428106927, 0.4);
+  test.hclEqual(c.darker(0.5), 32.282417816884454, 59.60396926239275, 29.149667346714935, 0.4);
+  test.hclEqual(c.darker(1), 32.282417816884454, 59.60396926239275, 20.149667346714935, 0.4);
+  test.hclEqual(c.darker(2), 32.282417816884454, 59.60396926239275, 2.149667346714935, 0.4);
   test.end();
 });
 
 tape("hcl.darker(k) returns a copy", function(test) {
   var c1 = color.hcl("rgba(70, 130, 180, 0.4)"),
       c2 = c1.darker(1);
-  test.hclEqual(c1, 262.78126775909277, 32.44906314974561, 52.46551718768575, 0.4);
-  test.hclEqual(c2, 262.78126775909277, 32.44906314974561, 34.46551718768575, 0.4);
+  test.hclEqual(c1, 255.71331691921011, 33.88051838788065, 51.98624890550498, 0.4);
+  test.hclEqual(c2, 255.71331691921011, 33.88051838788065, 33.98624890550498, 0.4);
   test.end();
 });
 
@@ -228,6 +228,6 @@ tape("hcl.darker(k) is equivalent to hcl.brighter(-k)", function(test) {
 
 tape("hcl.rgb() converts to RGB", function(test) {
   var c = color.hcl(120, 30, 50, 0.4);
-  test.rgbEqual(c.rgb(), 109, 125, 74, 0.4);
+  test.rgbEqual(c.rgb(), 105, 126, 73, 0.4);
   test.end();
 });

--- a/test/lab-test.js
+++ b/test/lab-test.js
@@ -13,7 +13,7 @@ tape("lab(…) returns an instance of lab and color", function(test) {
 });
 
 tape("lab(…) exposes l, a and b channel values and opacity", function(test) {
-  test.labEqual(color.lab("rgba(170, 187, 204, 0.4)"), 75.104975, -2.292115, -10.528266, 0.4);
+  test.labEqual(color.lab("rgba(170, 187, 204, 0.4)"), 74.96879980931759, -3.3963111407948054, -10.696507207853333, 0.4);
   test.end();
 });
 
@@ -32,7 +32,7 @@ tape("lab.toString() converts to RGB and formats as rgb(…) or rgba(…)", func
 tape("lab.toString() reflects l, a and b channel values and opacity", function(test) {
   var c = color.lab("#abc");
   c.l += 10, c.a -= 10, c.b += 10, c.opacity = 0.4;
-  test.equal(c + "", "rgba(186, 220, 213, 0.4)");
+  test.equal(c + "", "rgba(184, 220, 213, 0.4)");
   test.end();
 });
 
@@ -91,14 +91,14 @@ tape("lab(l, a, b, opacity) converts undefined opacity to 1", function(test) {
 });
 
 tape("lab(format) parses the specified format and converts to Lab", function(test) {
-  test.labEqual(color.lab("#abcdef"), 81.04386565274363, -3.6627002800885267, -20.442705201854984, 1);
-  test.labEqual(color.lab("#abc"), 75.10497524893663, -2.292114632248876, -10.528266458853786, 1);
-  test.labEqual(color.lab("rgb(12, 34, 56)"), 12.65624852526134, 0.12256520883417721, -16.833209795877284, 1);
-  test.labEqual(color.lab("rgb(12%, 34%, 56%)"), 36.040298589825746, 2.5504315155944477, -36.19963333647264, 1);
-  test.labEqual(color.lab("rgba(12%, 34%, 56%, 0.4)"), 36.040298589825746, 2.5504315155944477, -36.19963333647264, 0.4);
-  test.labEqual(color.lab("hsl(60,100%,20%)"), 41.73251953866431, -10.998411255098816, 48.21006600604577, 1);
-  test.labEqual(color.lab("hsla(60,100%,20%,0.4)"), 41.73251953866431, -10.998411255098816, 48.21006600604577, 0.4);
-  test.labEqual(color.lab("aliceblue"), 97.17864982306108, -1.3486158598345344, -4.262854157273543, 1);
+  test.labEqual(color.lab("#abcdef"), 80.77135418262527, -5.954255502216621, -20.785782794739237, 1);
+  test.labEqual(color.lab("#abc"), 74.96879980931759, -3.3963111407948054, -10.696507207853333, 1);
+  test.labEqual(color.lab("rgb(12, 34, 56)"), 12.404844123471648, -2.159118622594325, -17.168132391132946, 1);
+  test.labEqual(color.lab("rgb(12%, 34%, 56%)"), 35.48300043476593, -2.5061206989765994, -36.9511298319585, 1);
+  test.labEqual(color.lab("rgba(12%, 34%, 56%, 0.4)"), 35.48300043476593, -2.5061206989765994, -36.9511298319585, 0.4);
+  test.labEqual(color.lab("hsl(60,100%,20%)"), 41.97125732118659, -8.036679181988028, 47.65411917854332, 1);
+  test.labEqual(color.lab("hsla(60,100%,20%,0.4)"), 41.97125732118659, -8.036679181988028, 47.65411917854332, 0.4);
+  test.labEqual(color.lab("aliceblue"), 97.12294991108756, -1.7704775380631976, -4.332680308569969, 1);
   test.end();
 });
 
@@ -123,7 +123,7 @@ tape("lab(hcl(lab)) doesn’t lose a and b channels if luminance is zero", funct
 });
 
 tape("lab(rgb) converts from RGB", function(test) {
-  test.labEqual(color.lab(color.rgb(255, 0, 0, 0.4)), 53.24079414130722, 80.09245959641109, 67.20319651585301, 0.4);
+  test.labEqual(color.lab(color.rgb(255, 0, 0, 0.4)), 54.29173376861782, 80.81510892658389, 69.88504032350531, 0.4);
   test.end();
 });
 
@@ -132,23 +132,23 @@ tape("lab(color) converts from another colorspace via color.rgb()", function(tes
   TestColor.prototype = Object.create(color.color.prototype);
   TestColor.prototype.rgb = function() { return color.rgb(12, 34, 56, 0.4); };
   TestColor.prototype.toString = function() { throw new Error("should use rgb, not toString"); };
-  test.labEqual(color.lab(new TestColor), 12.65624852526134, 0.12256520883417721, -16.833209795877284, 0.4);
+  test.labEqual(color.lab(new TestColor), 12.404844123471648, -2.159118622594325, -17.168132391132946, 0.4);
   test.end();
 });
 
 tape("lab.brighter(k) returns a brighter color if k > 0", function(test) {
   var c = color.lab("rgba(165, 42, 42, 0.4)");
-  test.labEqual(c.brighter(0.5), 46.52650524281069, 49.69034644081097, 30.543166542619616, 0.4);
-  test.labEqual(c.brighter(1), 55.52650524281069, 49.69034644081097, 30.543166542619616, 0.4);
-  test.labEqual(c.brighter(2), 73.52650524281069, 49.69034644081097, 30.543166542619616, 0.4);
+  test.labEqual(c.brighter(0.5), 47.149667346714935, 50.39073152024248, 31.834059255569358, 0.4);
+  test.labEqual(c.brighter(1), 56.149667346714935, 50.39073152024248, 31.834059255569358, 0.4);
+  test.labEqual(c.brighter(2), 74.14966734671493, 50.39073152024248, 31.834059255569358, 0.4);
   test.end();
 });
 
 tape("lab.brighter(k) returns a copy", function(test) {
   var c1 = color.lab("rgba(70, 130, 180, 0.4)"),
       c2 = c1.brighter(1);
-  test.labEqual(c1, 52.46551718768575, -4.0774710123572255, -32.19186122981343, 0.4);
-  test.labEqual(c2, 70.46551718768575, -4.0774710123572255, -32.19186122981343, 0.4);
+  test.labEqual(c1, 51.98624890550498, -8.360823708064903, -32.832699449697685, 0.4);
+  test.labEqual(c2, 69.98624890550498, -8.360823708064903, -32.83269944969768, 0.4);
   test.end();
 });
 
@@ -170,17 +170,17 @@ tape("lab.brighter(k) is equivalent to lab.darker(-k)", function(test) {
 
 tape("lab.darker(k) returns a darker color if k > 0", function(test) {
   var c = color.lab("rgba(165, 42, 42, 0.4)");
-  test.labEqual(c.darker(0.5), 28.526505242810693, 49.69034644081097, 30.543166542619616, 0.4);
-  test.labEqual(c.darker(1), 19.526505242810693, 49.69034644081097, 30.543166542619616, 0.4);
-  test.labEqual(c.darker(2), 1.5265052428106927, 49.69034644081097, 30.543166542619616, 0.4);
+  test.labEqual(c.darker(0.5), 29.149667346714935, 50.39073152024248, 31.834059255569358, 0.4);
+  test.labEqual(c.darker(1), 20.149667346714935, 50.39073152024248, 31.834059255569358, 0.4);
+  test.labEqual(c.darker(2), 2.149667346714935, 50.39073152024248, 31.834059255569358, 0.4);
   test.end();
 });
 
 tape("lab.darker(k) returns a copy", function(test) {
   var c1 = color.lab("rgba(70, 130, 180, 0.4)"),
       c2 = c1.darker(1);
-  test.labEqual(c1, 52.46551718768575, -4.0774710123572255, -32.19186122981343, 0.4);
-  test.labEqual(c2, 34.46551718768575, -4.0774710123572255, -32.19186122981343, 0.4);
+  test.labEqual(c1, 51.98624890550498, -8.360823708064903, -32.832699449697685, 0.4);
+  test.labEqual(c2, 33.98624890550498, -8.360823708064903, -32.832699449697685, 0.4);
   test.end();
 });
 
@@ -202,6 +202,6 @@ tape("lab.darker(k) is equivalent to lab.brighter(-k)", function(test) {
 
 tape("lab.rgb() converts to RGB", function(test) {
   var c = color.lab(50, 4, -5, 0.4);
-  test.rgbEqual(c.rgb(), 122, 117, 127, 0.4);
+  test.rgbEqual(c.rgb(), 123, 117, 128, 0.4);
   test.end();
 });


### PR DESCRIPTION
I've added an example implementation for the chromatic adaptation described in #42. I still need to fix the tests after I find a reliable source to check against. 

(I've also added `tap-spec` to the dev dependencies, which makes the test output look nicer)