### PR TITLE
Add d3.lch, d3.gray aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ In addition to the ubiquitous and machine-friendly [RGB](#rgb) and [HSL](#hsl) c
 
 Cubehelix features monotonic lightness, while Lab and HCL are perceptually uniform. Note that HCL is the cylindrical form of Lab, similar to how HSL is the cylindrical form of RGB.
 
+For additional color spaces, see:
+
+* [d3-cam16](https://github.com/d3/d3-cam16)
+* [d3-cam02](https://github.com/connorgr/d3-cam02)
+* [d3-hsv](https://github.com/d3/d3-hsv)
+* [d3-hcg](https://github.com/d3/d3-hcg)
+
 ## Installing
 
 If you use NPM, `npm install d3-color`. Otherwise, download the [latest release](https://github.com/d3/d3-color/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-color.v1.min.js) or as part of [D3 4.0](https://github.com/d3/d3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If *h*, *s* and *l* are specified, these represent the channel values of the ret
 <a href="#lab">#</a> d3.<b>lab</b>(<i>specifier</i>)<br>
 <a href="#lab">#</a> d3.<b>lab</b>(<i>color</i>)<br>
 
-Constructs a new [Lab](https://en.wikipedia.org/wiki/Lab_color_space#CIELAB) color. The channel values are exposed as `l`, `a` and `b` properties on the returned instance. Use the [Lab color picker](http://bl.ocks.org/mbostock/9f37cc207c0cb166921b) to explore this color space.
+Constructs a new [Lab](https://en.wikipedia.org/wiki/Lab_color_space#CIELAB) color. The channel values are exposed as `l`, `a` and `b` properties on the returned instance. Use the [Lab color picker](http://bl.ocks.org/mbostock/9f37cc207c0cb166921b) to explore this color space. The value of *l* is typically in the range [0, 100], while *a* and *b* are typically in [-160, +160].
 
 If *l*, *a* and *b* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the Lab color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb) and then converted to Lab. (Colors already in the Lab color space skip the conversion to RGB, and colors in the HCL color space are converted directly to Lab.)
 
@@ -127,7 +127,7 @@ Constructs a new [Lab](#lab) color with the specified *l* value and *a* = *b* = 
 <a href="#hcl">#</a> d3.<b>hcl</b>(<i>specifier</i>)<br>
 <a href="#hcl">#</a> d3.<b>hcl</b>(<i>color</i>)<br>
 
-Constructs a new [HCL](https://en.wikipedia.org/wiki/HCL_color_space) color. The channel values are exposed as `h`, `c` and `l` properties on the returned instance. Use the [HCL color picker](http://bl.ocks.org/mbostock/3e115519a1b495e0bd95) to explore this color space.
+Constructs a new [HCL](https://en.wikipedia.org/wiki/HCL_color_space) color. The channel values are exposed as `h`, `c` and `l` properties on the returned instance. Use the [HCL color picker](http://bl.ocks.org/mbostock/3e115519a1b495e0bd95) to explore this color space. The value of *l* is typically in the range [0, 100], *c* is typically in [0, 230], and *h* is typically in [0, 360).
 
 If *h*, *c* and *l* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the HCL color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb) and then converted to HCL. (Colors already in the HCL color space skip the conversion to RGB, and colors in the Lab color space are converted directly to HCL.)
 

--- a/README.md
+++ b/README.md
@@ -75,27 +75,27 @@ Note: this function may also be used with `instanceof` to test if an object is a
 
 This color’s opacity, typically in the range [0, 1].
 
-<a name="color_rgb" href="#color_rgb">#</a> *color*.<b>rgb</b>() [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L209 "Source")
+<a name="color_rgb" href="#color_rgb">#</a> *color*.<b>rgb</b>() [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")
 
 Returns the [RGB equivalent](#rgb) of this color. For RGB colors, that’s `this`.
 
-<a name="color_brighter" href="#color_brighter">#</a> *color*.<b>brighter</b>([<i>k</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L221 "Source")
+<a name="color_brighter" href="#color_brighter">#</a> *color*.<b>brighter</b>([<i>k</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")
 
 Returns a brighter copy of this color. If *k* is specified, it controls how much brighter the returned color should be. If *k* is not specified, it defaults to 1. The behavior of this method is dependent on the implementing color space.
 
-<a name="color_darker" href="#color_darker">#</a> *color*.<b>darker</b>([<i>k</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L225 "Source")
+<a name="color_darker" href="#color_darker">#</a> *color*.<b>darker</b>([<i>k</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")
 
 Returns a darker copy of this color. If *k* is specified, it controls how much darker the returned color should be. If *k* is not specified, it defaults to 1. The behavior of this method is dependent on the implementing color space.
 
-<a name="color_displayable" href="#color_displayable">#</a> *color*.<b>displayable</b>() [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L169 "Source")
+<a name="color_displayable" href="#color_displayable">#</a> *color*.<b>displayable</b>() [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")
 
 Returns true if and only if the color is displayable on standard hardware. For example, this returns false for an RGB color if any channel value is less than zero or greater than 255, or if the opacity is not in the range [0, 1].
 
-<a name="color_toString" href="#color_toString">#</a> *color*.<b>toString</b>() [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L172 "Source")
+<a name="color_toString" href="#color_toString">#</a> *color*.<b>toString</b>() [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")
 
 Returns a string representing this color according to the [CSS Object Model specification](https://drafts.csswg.org/cssom/#serialize-a-css-component-value), such as `rgb(247, 234, 186)`. If this color is not displayable, a suitable displayable color is returned instead. For example, RGB channel values greater than 255 are clamped to 255.
 
-<a name="rgb" href="#rgb">#</a> d3.<b>rgb</b>(<i>r</i>, <i>g</i>, <i>b</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L209 "Source")<br>
+<a name="rgb" href="#rgb">#</a> d3.<b>rgb</b>(<i>r</i>, <i>g</i>, <i>b</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")<br>
 <a href="#rgb">#</a> d3.<b>rgb</b>(<i>specifier</i>)<br>
 <a href="#rgb">#</a> d3.<b>rgb</b>(<i>color</i>)<br>
 
@@ -103,7 +103,7 @@ Constructs a new [RGB](https://en.wikipedia.org/wiki/RGB_color_model) color. The
 
 If *r*, *g* and *b* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the RGB color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb). Note that unlike [*color*.rgb](#color_rgb) this method *always* returns a new instance, even if *color* is already an RGB color.
 
-<a name="hsl" href="#hsl">#</a> d3.<b>hsl</b>(<i>h</i>, <i>s</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js#L281 "Source")<br>
+<a name="hsl" href="#hsl">#</a> d3.<b>hsl</b>(<i>h</i>, <i>s</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/color.js "Source")<br>
 <a href="#hsl">#</a> d3.<b>hsl</b>(<i>specifier</i>)<br>
 <a href="#hsl">#</a> d3.<b>hsl</b>(<i>color</i>)<br>
 
@@ -111,7 +111,7 @@ Constructs a new [HSL](https://en.wikipedia.org/wiki/HSL_and_HSV) color. The cha
 
 If *h*, *s* and *l* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the HSL color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb) and then converted to HSL. (Colors already in the HSL color space skip the conversion to RGB.)
 
-<a name="lab" href="#lab">#</a> d3.<b>lab</b>(<i>l</i>, <i>a</i>, <i>b</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js#L30 "Source")<br>
+<a name="lab" href="#lab">#</a> d3.<b>lab</b>(<i>l</i>, <i>a</i>, <i>b</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js "Source")<br>
 <a href="#lab">#</a> d3.<b>lab</b>(<i>specifier</i>)<br>
 <a href="#lab">#</a> d3.<b>lab</b>(<i>color</i>)<br>
 
@@ -119,7 +119,7 @@ Constructs a new [Lab](https://en.wikipedia.org/wiki/Lab_color_space#CIELAB) col
 
 If *l*, *a* and *b* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the Lab color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb) and then converted to Lab. (Colors already in the Lab color space skip the conversion to RGB, and colors in the HCL color space are converted directly to Lab.)
 
-<a name="hcl" href="#hcl">#</a> d3.<b>hcl</b>(<i>h</i>, <i>c</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js#L87 "Source")<br>
+<a name="hcl" href="#hcl">#</a> d3.<b>hcl</b>(<i>h</i>, <i>c</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js "Source")<br>
 <a href="#hcl">#</a> d3.<b>hcl</b>(<i>specifier</i>)<br>
 <a href="#hcl">#</a> d3.<b>hcl</b>(<i>color</i>)<br>
 
@@ -127,7 +127,13 @@ Constructs a new [HCL](https://en.wikipedia.org/wiki/HCL_color_space) color. The
 
 If *h*, *c* and *l* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the HCL color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb) and then converted to HCL. (Colors already in the HCL color space skip the conversion to RGB, and colors in the Lab color space are converted directly to HCL.)
 
-<a name="cubehelix" href="#cubehelix">#</a> d3.<b>cubehelix</b>(<i>h</i>, <i>s</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/cubehelix.js#L32 "Source")<br>
+<a name="lch" href="#lch">#</a> d3.<b>lch</b>( <i>l</i>, <i>c</i>,<i>h</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js "Source")<br>
+<a href="#lch">#</a> d3.<b>lch</b>(<i>specifier</i>)<br>
+<a href="#lch">#</a> d3.<b>lch</b>(<i>color</i>)<br>
+
+Equivalent to [d3.hcl](#hcl), but with reversed argument order.
+
+<a name="cubehelix" href="#cubehelix">#</a> d3.<b>cubehelix</b>(<i>h</i>, <i>s</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/cubehelix.js "Source")<br>
 <a href="#cubehelix">#</a> d3.<b>cubehelix</b>(<i>specifier</i>)<br>
 <a href="#cubehelix">#</a> d3.<b>cubehelix</b>(<i>color</i>)<br>
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Constructs a new [Lab](https://en.wikipedia.org/wiki/Lab_color_space#CIELAB) col
 
 If *l*, *a* and *b* are specified, these represent the channel values of the returned color; an *opacity* may also be specified. If a CSS Color Module Level 3 *specifier* string is specified, it is parsed and then converted to the Lab color space. See [color](#color) for examples. If a [*color*](#color) instance is specified, it is converted to the RGB color space using [*color*.rgb](#color_rgb) and then converted to Lab. (Colors already in the Lab color space skip the conversion to RGB, and colors in the HCL color space are converted directly to Lab.)
 
+<a name="gray" href="#gray">#</a> d3.<b>gray</b>(<i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js "Source")<br>
+
+Constructs a new [Lab](#lab) color with the specified *l* value and *a* = *b* = 0.
+
 <a name="hcl" href="#hcl">#</a> d3.<b>hcl</b>(<i>h</i>, <i>c</i>, <i>l</i>[, <i>opacity</i>]) [<>](https://github.com/d3/d3-color/blob/master/src/lab.js "Source")<br>
 <a href="#hcl">#</a> d3.<b>hcl</b>(<i>specifier</i>)<br>
 <a href="#hcl">#</a> d3.<b>hcl</b>(<i>color</i>)<br>

--- a/d3-color.sublime-project
+++ b/d3-color.sublime-project
@@ -2,12 +2,16 @@
   "folders": [
     {
       "path": ".",
-      "file_exclude_patterns": [
-        "*.sublime-workspace"
-      ],
-      "folder_exclude_patterns": [
-        "build"
-      ]
+      "file_exclude_patterns": ["*.sublime-workspace"],
+      "folder_exclude_patterns": ["build"]
+    }
+  ],
+  "build_systems": [
+    {
+      "name": "npm",
+      "cmd": ["npm", "test"],
+      "file_regex": "\\((...*?):([0-9]*):([0-9]*)\\)",
+      "working_dir": "$project_path"
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 export {default as color, rgb, hsl} from "./src/color";
-export {default as lab, hcl} from "./src/lab";
+export {default as lab, hcl, lch} from "./src/lab";
 export {default as cubehelix} from "./src/cubehelix";

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 export {default as color, rgb, hsl} from "./src/color";
-export {default as lab, hcl, lch} from "./src/lab";
+export {default as lab, hcl, lch, gray} from "./src/lab";
 export {default as cubehelix} from "./src/cubehelix";

--- a/src/lab.js
+++ b/src/lab.js
@@ -89,6 +89,10 @@ function hclConvert(o) {
   return new Hcl(h < 0 ? h + 360 : h, Math.sqrt(o.a * o.a + o.b * o.b), o.l, o.opacity);
 }
 
+export function lch(l, c, h, opacity) {
+  return arguments.length === 1 ? hclConvert(l) : new Hcl(h, c, l, opacity == null ? 1 : opacity);
+}
+
 export function hcl(h, c, l, opacity) {
   return arguments.length === 1 ? hclConvert(h) : new Hcl(h, c, l, opacity == null ? 1 : opacity);
 }

--- a/src/lab.js
+++ b/src/lab.js
@@ -31,6 +31,10 @@ function labConvert(o) {
   return new Lab(116 * y - 16, 500 * (x - y), 200 * (y - z), o.opacity);
 }
 
+export function gray(l, opacity) {
+  return new Lab(l, 0, 0, opacity == null ? 1 : opacity);
+}
+
 export default function lab(l, a, b, opacity) {
   return arguments.length === 1 ? labConvert(l) : new Lab(l, a, b, opacity == null ? 1 : opacity);
 }

--- a/test/gray-test.js
+++ b/test/gray-test.js
@@ -1,0 +1,12 @@
+var tape = require("tape"),
+    color = require("../");
+
+require("./labEqual");
+
+tape("gray(l[, opacity]) is an alias for lab(l, 0, 0[, opacity])", function(test) {
+  test.labEqual(color.gray(120), 120, 0, 0, 1);
+  test.labEqual(color.gray(120, 0.5), 120, 0, 0, 0.5);
+  test.labEqual(color.gray(120, null), 120, 0, 0, 1);
+  test.labEqual(color.gray(120, undefined), 120, 0, 0, 1);
+  test.end();
+});

--- a/test/lch-test.js
+++ b/test/lch-test.js
@@ -1,0 +1,19 @@
+var tape = require("tape"),
+    color = require("../");
+
+require("./hclEqual");
+
+tape("lch(color) is equivalent to hcl(color)", function(test) {
+  test.hclEqual(color.lch("#abc"), 252.37145234745182, 11.223567114593477, 74.96879980931759, 1);
+  test.hclEqual(color.lch(color.rgb("#abc")), 252.37145234745182, 11.223567114593477, 74.96879980931759, 1);
+  test.end();
+});
+
+tape("lch(l, c, h[, opacity]) is equivalent to hcl(h, c, l[, opacity])", function(test) {
+  test.hclEqual(color.lch(74, 11, 252), 252, 11, 74, 1);
+  test.hclEqual(color.lch(74, 11, 252), 252, 11, 74, 1);
+  test.hclEqual(color.lch(74, 11, 252, null), 252, 11, 74, 1);
+  test.hclEqual(color.lch(74, 11, 252, undefined), 252, 11, 74, 1);
+  test.hclEqual(color.lch(74, 11, 252, 0.5), 252, 11, 74, 0.5);
+  test.end();
+});


### PR DESCRIPTION
d3.lch is a convenience wrapper on top of d3.hcl with inverted argument order.

d3.gray is a convenience wrapper on top of d3.lab with *a* = *b* = 0.