### PR TITLE
Refactor XYZ color space into its own module.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export {default as color, rgb, hsl} from "./color.js";
 export {default as lab, hcl, lch, gray} from "./lab.js";
 export {default as cubehelix} from "./cubehelix.js";
+export {default as xyz} from "./xyz.js";

--- a/src/lab.js
+++ b/src/lab.js
@@ -1,12 +1,10 @@
 import define, {extend} from "./define.js";
-import {Color, rgbConvert, Rgb} from "./color.js";
+import {Color} from "./color.js";
 import {degrees, radians} from "./math.js";
+import {Xyz, xyzConvert} from "./xyz.js";
 
 // https://observablehq.com/@mbostock/lab-and-rgb
 const K = 18,
-    Xn = 0.96422,
-    Yn = 1,
-    Zn = 0.82521,
     t0 = 4 / 29,
     t1 = 6 / 29,
     t2 = 3 * t1 * t1,
@@ -15,15 +13,10 @@ const K = 18,
 function labConvert(o) {
   if (o instanceof Lab) return new Lab(o.l, o.a, o.b, o.opacity);
   if (o instanceof Hcl) return hcl2lab(o);
-  if (!(o instanceof Rgb)) o = rgbConvert(o);
-  var r = rgb2lrgb(o.r),
-      g = rgb2lrgb(o.g),
-      b = rgb2lrgb(o.b),
-      y = xyz2lab((0.2225045 * r + 0.7168786 * g + 0.0606169 * b) / Yn), x, z;
-  if (r === g && g === b) x = z = y; else {
-    x = xyz2lab((0.4360747 * r + 0.3850649 * g + 0.1430804 * b) / Xn);
-    z = xyz2lab((0.0139322 * r + 0.0971045 * g + 0.7141733 * b) / Zn);
-  }
+  if (!(o instanceof Xyz)) o = xyzConvert(o);
+  var x = xyz2lab(o.x),
+      y = xyz2lab(o.y),
+      z = xyz2lab(o.z);
   return new Lab(116 * y - 16, 500 * (x - y), 200 * (y - z), o.opacity);
 }
 
@@ -53,15 +46,10 @@ define(Lab, lab, extend(Color, {
     var y = (this.l + 16) / 116,
         x = isNaN(this.a) ? y : y + this.a / 500,
         z = isNaN(this.b) ? y : y - this.b / 200;
-    x = Xn * lab2xyz(x);
-    y = Yn * lab2xyz(y);
-    z = Zn * lab2xyz(z);
-    return new Rgb(
-      lrgb2rgb( 3.1338561 * x - 1.6168667 * y - 0.4906146 * z),
-      lrgb2rgb(-0.9787684 * x + 1.9161415 * y + 0.0334540 * z),
-      lrgb2rgb( 0.0719453 * x - 0.2289914 * y + 1.4052427 * z),
-      this.opacity
-    );
+    x = lab2xyz(x);
+    y = lab2xyz(y);
+    z = lab2xyz(z);
+    return new Xyz(x, y, z, this.opacity).rgb();
   }
 }));
 
@@ -71,14 +59,6 @@ function xyz2lab(t) {
 
 function lab2xyz(t) {
   return t > t1 ? t * t * t : t2 * (t - t0);
-}
-
-function lrgb2rgb(x) {
-  return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
-}
-
-function rgb2lrgb(x) {
-  return (x /= 255) <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
 }
 
 function hclConvert(o) {

--- a/src/xyz.js
+++ b/src/xyz.js
@@ -1,0 +1,75 @@
+import define, {extend} from "./define.js";
+import {Color, rgbConvert, Rgb} from "./color.js";
+
+/* CIE XYZ D50 */
+
+const Xn = 0.96422,
+    Yn = 1,
+    Zn = 0.82521,
+    // For converting from lRGB to XYZ.
+    ry = 0.2225045,
+    gy = 0.7168786,
+    by = 0.0606169,
+    rx = 0.4360747,
+    gx = 0.3850649,
+    bx = 0.1430804,
+    rz = 0.0139322,
+    gz = 0.0971045,
+    bz = 0.7141733,
+    // For converting from XYZ to lRGB.
+    xr = 3.1338561,
+    yr = -1.6168667,
+    zr = -0.4906146,
+    xg = -0.9787684,
+    yg = 1.9161415,
+    zg = 0.0334540,
+    xb = 0.0719453,
+    yb = -0.2289914,
+    zb = 1.4052427;
+
+
+
+function rgb2lrgb(x) {
+  return (x /= 255) <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+}
+
+export function xyzConvert(o) {
+  if (o instanceof Xyz) return new Xyz(o.x, o.y, o.z, o.opacity);
+  if (!(o instanceof Rgb)) o = rgbConvert(o);
+  var r = rgb2lrgb(o.r),
+      g = rgb2lrgb(o.g),
+      b = rgb2lrgb(o.b),
+      y = ((ry * r) + (gy * g) + (by * b)) / Yn, x, z;
+  if (r === g && g === b) x = z = y; else {
+    x = ((rx * r) + (gx * g) + (bx * b)) / Xn,
+    z = ((rz * r) + (gz * g) + (bz * b)) / Zn;
+  }
+  return new Xyz(x, y, z, o.opacity);
+}
+
+export default function xyz(x, y, z, opacity) {
+  return arguments.length === 1 ? xyzConvert(x) : new Xyz(x, y, z, opacity == null ? 1 : opacity);
+}
+  
+export function Xyz(x, y, z, opacity) {
+  this.x = +x;
+  this.y = +y;
+  this.z = +z;
+  this.opacity = +opacity;
+}
+
+function lrgb2rgb(x) {
+  return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
+}
+  
+define(Xyz, xyz, extend(Color, {
+  rgb: function() {
+    var x = Xn * this.x,
+        y = Yn * this.y,
+        z = Zn * this.z,
+        r = (xr * x) + (yr * y) + (zr * z),
+        g = (xg * x) + (yg * y) + (zg * z),
+        b = (xb * x) + (yb * y) + (zb * z);
+    return new Rgb(lrgb2rgb(r), lrgb2rgb(g), lrgb2rgb(b), this.opacity);
+  }
+}));

--- a/test/xyzEqual.js
+++ b/test/xyzEqual.js
@@ -1,0 +1,19 @@
+var tape = require("tape"),
+    color = require("../");
+
+function floatEqual(got, want, epsilon=1e-6) {
+  return isNaN(want) ? (isNaN(got) && got !== got) : (Math.abs(want - got) <= epsilon);
+}
+
+tape.Test.prototype.xyzEqual = function(actual, x, y, z, opacity) {
+  this._assert(actual instanceof color.xyz
+      && floatEqual(actual.x, x)
+      && floatEqual(actual.y, y)
+      && floatEqual(actual.z, z)
+      && floatEqual(actual.opacity, opacity), {
+    message: "should be equal",
+    operator: "xyzEqual",
+    actual: [actual.x, actual.y, actual.z, actual.opacity],
+    expected: [x, y, z, opacity],
+  });
+};


### PR DESCRIPTION
For [#51](https://github.com/d3/d3-color/issues/51)

Refactors the implementation of the XYZ color space (i.e. CIE XYZ D50) out of `src/lab.js` into its own module, `src/xyz.js`.