### PR TITLE
avoid catastrophic backtracking

### DIFF
--- a/test/color-test.js
+++ b/test/color-test.js
@@ -59,6 +59,10 @@ it("color(format) parses HSLA format (e.g., \"hsla(60,100%,20%,0.4)\")", () => {
   assertHslEqual(color("hsla(60,100%,20%,0.4)"), 60, 1, 0.2, 0.4);
 });
 
+it("color(format) disallows invalid hexadecimal (e.g., \"#abcdef no\")", () => {
+  assert.strictEqual(color("#abcdef no"), null);
+});
+
 it("color(format) ignores leading and trailing whitespace", () => {
   assertRgbApproxEqual(color(" aliceblue\t\n"), 240, 248, 255, 1);
   assertRgbApproxEqual(color(" #abc\t\n"), 170, 187, 204, 1);


### PR DESCRIPTION
Fixes #97. Supersedes #89. No change in behavior; just a new implementation that uses a tokenizer and a positive lookahead to mimic an atomic group.

Demo: https://observablehq.com/d/ae672b8cd8dacfab

On my computer, the input with 200,000 repeating ones took 57 seconds with the current version of d3-color, and <1ms with this new approach.