### PR TITLE
avoid backtracking

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -6,8 +6,8 @@ export var darker = 0.7;
 export var brighter = 1 / darker;
 
 var reI = "\\s*([+-]?\\d+)\\s*",
-    reN = "\\s*([+-]?\\d*\\.?\\d+(?:[eE][+-]?\\d+)?)\\s*",
-    reP = "\\s*([+-]?\\d*\\.?\\d+(?:[eE][+-]?\\d+)?)%\\s*",
+    reN = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*",
+    reP = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*",
     reHex = /^#([0-9a-f]{3,8})$/,
     reRgbInteger = new RegExp("^rgb\\(" + [reI, reI, reI] + "\\)$"),
     reRgbPercent = new RegExp("^rgb\\(" + [reP, reP, reP] + "\\)$"),


### PR DESCRIPTION
Fixes #97. Supersedes #89 and #99. The problem was that this expression is fundamentally ambiguous:

```
/\s*([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)%\s*/
```

Since both the dot and the digits preceding the dot are optional, there’s a combinatorial explosion of possible valid matches. If we instead combine it into an optional group and make the dot required for that group, the explosion is avoided:

```
/\s*([+-]?(?:\d*\.)?\d+(?:[eE][+-]?\d+)?)%\s*/
```

Demo: https://observablehq.com/d/4b1d645fe3da1226